### PR TITLE
Fix markdown rendering of plotly modules' functions

### DIFF
--- a/_plotly_utils/colors/__init__.py
+++ b/_plotly_utils/colors/__init__.py
@@ -425,11 +425,18 @@ def convert_colors_to_same_type(
     be coverted to the selected colortype. If colors is None, then there is an
     option to return portion of the DEFAULT_PLOTLY_COLORS
 
-    :param (str|tuple|list) colors: either a plotly scale name, an rgb or hex
+    Parameters
+    ----------
+    colors : str or tuple or list 
+        Either a plotly scale name, an rgb or hex
         color, a color tuple or a list/tuple of colors
-    :param (list) scale: see docs for validate_scale_values()
+    scale : list 
+        See docs for validate_scale_values()
 
-    :rtype (tuple) (colors_list, scale) if scale is None in the function call,
+    Returns
+    -------
+    A tuple of (colors_list, scale) 
+        If scale is None in the function call,
         then scale will remain None in the returned tuple
     """
     colors_list = []
@@ -495,7 +502,10 @@ def convert_dict_colors_to_same_type(colors_dict, colortype="rgb"):
     """
     Converts a colors in a dictionary of colors to the specified color type
 
-    :param (dict) colors_dict: a dictionary whose values are single colors
+    Parameters
+    ----------
+    colors_dict : dict
+        A dictionary whose values are single colors
     """
     for key in colors_dict:
         if "#" in colors_dict[key]:
@@ -523,7 +533,10 @@ def validate_scale_values(scale):
     """
     Validates scale values from a colorscale
 
-    :param (list) scale: a strictly increasing list of floats that begins
+    Parameters
+    ----------
+    scale : list 
+        A strictly increasing list of floats that begins
         with 0 and ends with 1. Its usage derives from a colorscale which is
         a list of two-lists (a list with two elements) of the form
         [value, color] which are used to determine how interpolation weighting
@@ -570,9 +583,12 @@ def make_colorscale(colors, scale=None):
     interpolated colorscale will be generated. If 'scale' is a specificed
     list, it must be the same legnth as colors and must contain all floats
     For documentation regarding to the form of the output, see
-    https://plot.ly/python/reference/#mesh3d-colorscale
+    [https://plotly.com/python/reference/#mesh3d-colorscale](/reference/graph_objects/Mesh3d.md#plotly.graph_objects.Mesh3d.colorscale)
 
-    :param (list) colors: a list of single colors
+    Parameters
+    ----------
+    colors : list 
+        A list of single colors
     """
     colorscale = []
 
@@ -652,7 +668,10 @@ def convert_to_RGB_255(colors):
     to just x. This is the way rounding works in Python 3 and in current
     statistical analysis to avoid rounding bias
 
-    :param (list) rgb_components: grabs the three R, G and B values to be
+    Parameters
+    ----------
+    rgb_components : list 
+        Grabs the three R, G and B values to be
         returned as computed in the function
     """
     rgb_components = []
@@ -752,9 +771,15 @@ def hex_to_rgb(value):
     """
     Calculates rgb values from a hex color code.
 
-    :param (string) value: Hex color string
+    Parameters
+    ----------
+    value : str 
+        Hex color string
 
-    :rtype (tuple) (r_value, g_value, b_value): tuple of rgb values
+    Returns
+    -------
+    A tuple of (r_value, g_value, b_value)
+        Tuple of rgb values
     """
     value = value.lstrip("#")
     hex_total_length = len(value)

--- a/plotly/colors/__init__.py
+++ b/plotly/colors/__init__.py
@@ -2,9 +2,9 @@
 
 """For a list of colors available in `plotly.colors`, please see
 
-* the `tutorial on discrete color sequences <https://plotly.com/python/discrete-color/#color-sequences-in-plotly-express>`_
-* the `list of built-in continuous color scales <https://plotly.com/python/builtin-colorscales/>`_
-* the `tutorial on continuous colors <https://plotly.com/python/colorscales/>`_
+* the [tutorial on discrete color sequences https://plotly.com/python/discrete-color/#color-sequences-in-plotly-express](/discrete-color.md#color-sequences-in-plotly-express)
+* the [list of built-in continuous color scales https://plotly.com/python/builtin-colorscales/](/builtin-colorscales.md)
+* the [tutorial on continuous colors https://plotly.com/python/colorscales/](/colorscales.md)
 
 Color scales and sequences are available within the following namespaces
 

--- a/plotly/data/__init__.py
+++ b/plotly/data/__init__.py
@@ -21,7 +21,7 @@ def gapminder(
     """
     Each row represents a country on a given year.
 
-    https://www.gapminder.org/data/
+    <https://www.gapminder.org/data/>
 
     Parameters
     ----------
@@ -88,7 +88,7 @@ def tips(pretty_names=False, return_type="pandas"):
     """
     Each row represents a restaurant bill.
 
-    https://vincentarelbundock.github.io/Rdatasets/doc/reshape2/tips.html
+    <https://vincentarelbundock.github.io/Rdatasets/doc/reshape2/tips.html>
 
     Parameters
     ----------
@@ -125,7 +125,7 @@ def iris(return_type="pandas"):
     """
     Each row represents a flower.
 
-    https://en.wikipedia.org/wiki/Iris_flower_data_set
+    <https://en.wikipedia.org/wiki/Iris_flower_data_set>
 
     Parameters
     ----------

--- a/plotly/express/__init__.py
+++ b/plotly/express/__init__.py
@@ -2,7 +2,7 @@
 
 """
 `plotly.express` is a terse, consistent, high-level wrapper around `plotly.graph_objects`
-for rapid data exploration and figure generation. Learn more at https://plotly.com/python/plotly-express/
+for rapid data exploration and figure generation. Learn more at [https://plotly.com/python/plotly-express/](/plotly-express.md)
 """
 
 from plotly import optional_imports

--- a/plotly/express/_chart_types.py
+++ b/plotly/express/_chart_types.py
@@ -5690,7 +5690,7 @@ def scatter_mapbox(
     warn(
         "*scatter_mapbox* is deprecated!"
         + " Use *scatter_map* instead."
-        + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/",
+        + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/.",
         stacklevel=2,
         category=DeprecationWarning,
     )
@@ -5727,7 +5727,7 @@ def choropleth_mapbox(
 ) -> go.Figure:
     """
     *choropleth_mapbox* is deprecated! Use *choropleth_map* instead.
-    Learn more at: https://plotly.com/python/mapbox-to-maplibre/
+    Learn more at: https://plotly.com/python/mapbox-to-maplibre/.
     In a Mapbox choropleth map, each row of `data_frame` is represented by a
     colored region on a Mapbox map.
 
@@ -5895,7 +5895,7 @@ def density_mapbox(
 ) -> go.Figure:
     """
     *density_mapbox* is deprecated! Use *density_map* instead.
-    Learn more at: https://plotly.com/python/mapbox-to-maplibre/
+    Learn more at: https://plotly.com/python/mapbox-to-maplibre/.
     In a Mapbox density map, each row of `data_frame` contributes to the intensity of
     the color of the region around the corresponding point on the map
 
@@ -6169,7 +6169,7 @@ def line_mapbox(
     warn(
         "*line_mapbox* is deprecated!"
         + " Use *line_map* instead."
-        + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/",
+        + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/.",
         stacklevel=2,
         category=DeprecationWarning,
     )

--- a/plotly/express/_core.py
+++ b/plotly/express/_core.py
@@ -100,10 +100,12 @@ MAPBOX_TOKEN = None
 
 def set_mapbox_access_token(token):
     """
-    Arguments:
-        token (Mapbox token): A Mapbox token to be used in `plotly.express.scatter_mapbox` \
+    Parameters
+    ----------
+    token : Mapbox token 
+        A Mapbox token to be used in `plotly.express.scatter_mapbox` \
         and `plotly.express.line_mapbox` figures. See \
-        https://docs.mapbox.com/help/how-mapbox-works/access-tokens/ for more details.
+        <https://docs.mapbox.com/help/how-mapbox-works/access-tokens/> for more details.
     """
     global MAPBOX_TOKEN
     MAPBOX_TOKEN = token
@@ -114,10 +116,15 @@ def get_trendline_results(fig):
     Extracts fit statistics for trendlines (when applied to figures generated with
     the `trendline` argument set to `"ols"`).
 
-    Arguments:
-        fig (figure): the output of a `plotly.express` charting call
-    Returns:
-        A `pandas.DataFrame` with a column "px_fit_results" containing the `statsmodels`
+    Parameters
+    ----------
+    fig : Figure 
+        The output of a `plotly.express` charting call
+    
+    Returns
+    -------
+    `pandas.DataFrame`
+        With a column "px_fit_results" containing the `statsmodels`
         results objects, along with columns identifying the subset of the data the
         trendline was fit on.
     """

--- a/plotly/express/_imshow.py
+++ b/plotly/express/_imshow.py
@@ -215,7 +215,8 @@ def imshow(
 
     Returns
     -------
-    fig : graph_objects.Figure containing the displayed image
+    fig : plotly.graph_objects.Figure 
+        Contains the displayed image
 
     See also
     --------

--- a/plotly/figure_factory/_2d_density.py
+++ b/plotly/figure_factory/_2d_density.py
@@ -30,7 +30,7 @@ def create_2d_density(
     width=600,
 ):
     """
-    **Deprecated**, use instead :func:`plotly.express.density_heatmap`.
+    **Deprecated**, use instead [`plotly.express.density_heatmap`](/reference/plotly-express.md#plotly.express.density_heatmap).
 
     Parameters
     ----------

--- a/plotly/figure_factory/_2d_density.py
+++ b/plotly/figure_factory/_2d_density.py
@@ -30,25 +30,37 @@ def create_2d_density(
     width=600,
 ):
     """
-    **deprecated**, use instead
-    :func:`plotly.express.density_heatmap`.
+    **Deprecated**, use instead :func:`plotly.express.density_heatmap`.
 
-    :param (list|array) x: x-axis data for plot generation
-    :param (list|array) y: y-axis data for plot generation
-    :param (str|tuple|list) colorscale: either a plotly scale name, an rgb
+    Parameters
+    ----------
+    x : list or array
+        x-axis data for plot generation.
+    y : list or array
+        y-axis data for plot generation.
+    colorscale : str or tuple or list
+        Either a plotly scale name, an rgb
         or hex color, a color tuple or a list or tuple of colors. An rgb
         color is of the form 'rgb(x, y, z)' where x, y, z belong to the
         interval [0, 255] and a color tuple is a tuple of the form
         (a, b, c) where a, b and c belong to [0, 1]. If colormap is a
         list, it must contain the valid color types aforementioned as its
         members.
-    :param (int) ncontours: the number of 2D contours to draw on the plot
-    :param (str) hist_color: the color of the plotted histograms
-    :param (str) point_color: the color of the scatter points
-    :param (str) point_size: the color of the scatter points
-    :param (str) title: set the title for the plot
-    :param (float) height: the height of the chart
-    :param (float) width: the width of the chart
+    ncontours : int
+        The number of 2D contours to draw on the plot.
+    hist_color : str
+        The color of the plotted histograms.
+    point_color : str
+        The color of the scatter points.
+    point_size : str
+        The size of the scatter points.
+    title : str
+        Set the title for the plot.
+    height : float
+        The height of the chart.
+    width : float
+        The width of the chart.
+
 
     Examples
     --------

--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -57,32 +57,44 @@ def create_annotated_heatmap(
     **kwargs,
 ):
     """
-    **deprecated**, use instead
-    :func:`plotly.express.imshow`.
+    **Deprecated**, use instead :func:`plotly.express.imshow`.
 
-    Function that creates annotated heatmaps
+    Function that creates annotated heatmaps.
 
     This function adds annotations to each cell of the heatmap.
 
-    :param (list[list]|ndarray) z: z matrix to create heatmap.
-    :param (list) x: x axis labels.
-    :param (list) y: y axis labels.
-    :param (list[list]|ndarray) annotation_text: Text strings for
-        annotations. Should have the same dimensions as the z matrix. If no
-        text is added, the values of the z matrix are annotated. Default =
-        z matrix values.
-    :param (list|str) colorscale: heatmap colorscale.
-    :param (list) font_colors: List of two color strings: [min_text_color,
+    Parameters
+    ----------
+    z : list[list] or ndarray
+        z matrix to create heatmap.
+    x : list
+        x axis labels.
+    y : list
+        y axis labels.
+    annotation_text : list[list] or ndarray
+        Text strings for annotations. Should have the same dimensions 
+        as the z matrix. If no text is added, the values of the z matrix 
+        are annotated. Default = z matrix values.
+    colorscale : list or str
+        Heatmap colorscale.
+    font_colors : list
+        List of two color strings: [min_text_color,
         max_text_color] where min_text_color is applied to annotations for
         heatmap values < (max_value - min_value)/2. If font_colors is not
         defined, the colors are defined logically as black or white
         depending on the heatmap's colorscale.
-    :param (bool) showscale: Display colorscale. Default = False
-    :param (bool) reversescale: Reverse colorscale. Default = False
-    :param kwargs: kwargs passed through plotly.graph_objects.Heatmap.
+    showscale : bool
+        Display colorscale. Default = False.
+    reversescale : bool
+        Reverse colorscale. Default = False.
+    **kwargs :
+        kwargs passed through plotly.graph_objects.Heatmap.
         These kwargs describe other attributes about the annotated Heatmap
         trace such as the colorscale. For more information on valid kwargs
         call help(plotly.graph_objects.Heatmap)
+
+    Examples
+    --------
 
     Example 1: Simple annotated heatmap with default configuration
 

--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -57,7 +57,7 @@ def create_annotated_heatmap(
     **kwargs,
 ):
     """
-    **Deprecated**, use instead :func:`plotly.express.imshow`.
+    **Deprecated**, use instead [`plotly.express.imshow`](/reference/plotly-express.md#plotly.express.imshow).
 
     Function that creates annotated heatmaps.
 

--- a/plotly/figure_factory/_bullet.py
+++ b/plotly/figure_factory/_bullet.py
@@ -195,45 +195,62 @@ def create_bullet(
     **layout_options,
 ):
     """
-    **deprecated**, use instead the plotly.graph_objs trace
+    **Deprecated**, use instead the plotly.graph_objs trace
     :class:`plotly.graph_objs.Indicator`.
 
-    :param (pd.DataFrame | list | tuple) data: either a list/tuple of
-        dictionaries or a pandas DataFrame.
-    :param (str) markers: the column name or dictionary key for the markers in
+    Parameters
+    ----------
+    data : pd.DataFrame or list or tuple
+        Either a list/tuple of dictionaries or a pandas DataFrame.
+    markers : str
+        The column name or dictionary key for the markers in
         each subplot.
-    :param (str) measures: the column name or dictionary key for the measure
+    measures : str
+        The column name or dictionary key for the measure
         bars in each subplot. This bar usually represents the quantitative
         measure of performance, usually a list of two values [a, b] and are
         the blue bars in the foreground of each subplot by default.
-    :param (str) ranges: the column name or dictionary key for the qualitative
+    ranges : str
+        The column name or dictionary key for the qualitative
         ranges of performance, usually a 3-item list [bad, okay, good]. They
         correspond to the grey bars in the background of each chart.
-    :param (str) subtitles: the column name or dictionary key for the subtitle
+    subtitles : str
+        The column name or dictionary key for the subtitle
         of each subplot chart. The subplots are displayed right underneath
         each title.
-    :param (str) titles: the column name or dictionary key for the main label
+    titles: str
+        The column name or dictionary key for the main label
         of each subplot chart.
-    :param (bool) orientation: if 'h', the bars are placed horizontally as
+    orientation : bool
+        If 'h', the bars are placed horizontally as
         rows. If 'v' the bars are placed vertically in the chart.
-    :param (list) range_colors: a tuple of two colors between which all
+    range_colors : list
+        A tuple of two colors between which all
         the rectangles for the range are drawn. These rectangles are meant to
         be qualitative indicators against which the marker and measure bars
         are compared.
         Default=('rgb(200, 200, 200)', 'rgb(245, 245, 245)')
-    :param (list) measure_colors: a tuple of two colors which is used to color
+    measure_colors : list
+        A tuple of two colors which is used to color
         the thin quantitative bars in the bullet chart.
         Default=('rgb(31, 119, 180)', 'rgb(176, 196, 221)')
-    :param (float) horizontal_spacing: see the 'horizontal_spacing' param in
+    horizontal_spacing : float
+        See the 'horizontal_spacing' param in
         plotly.tools.make_subplots. Ranges between 0 and 1.
-    :param (float) vertical_spacing: see the 'vertical_spacing' param in
+    vertical_spacing : float
+        See the 'vertical_spacing' param in
         plotly.tools.make_subplots. Ranges between 0 and 1.
-    :param (dict) scatter_options: describes attributes for the scatter trace
+    scatter_options : dict
+        Describes attributes for the scatter trace
         in each subplot such as name and marker size. Call
         help(plotly.graph_objects.Scatter) for more information on valid params.
-    :param layout_options: describes attributes for the layout of the figure
+    layout_options :
+        Describes attributes for the layout of the figure
         such as title, height and width. Call help(plotly.graph_objects.Layout)
         for more information on valid params.
+
+    Examples
+    --------    
 
     Example 1: Use a Dictionary
 

--- a/plotly/figure_factory/_bullet.py
+++ b/plotly/figure_factory/_bullet.py
@@ -195,8 +195,8 @@ def create_bullet(
     **layout_options,
 ):
     """
-    **Deprecated**, use instead the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Indicator`.
+    **Deprecated**, use instead the plotly.graph_objects trace
+    [`plotly.graph_objects.Indicator`](/reference/graph_objects/Indicator.md).
 
     Parameters
     ----------

--- a/plotly/figure_factory/_candlestick.py
+++ b/plotly/figure_factory/_candlestick.py
@@ -117,8 +117,8 @@ def make_decreasing_candle(open, high, low, close, dates, **kwargs):
 
 def create_candlestick(open, high, low, close, dates=None, direction="both", **kwargs):
     """
-    **Deprecated**, use instead the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Candlestick`
+    **Deprecated**, use instead the plotly.graph_objects trace
+    [`plotly.graph_objects.Candlestick`](/reference/graph_objects/Candlestick.md)
 
     Parameters
     ----------

--- a/plotly/figure_factory/_candlestick.py
+++ b/plotly/figure_factory/_candlestick.py
@@ -17,16 +17,26 @@ def make_increasing_candle(open, high, low, close, dates, **kwargs):
     when direction is set to 'increasing' or 'decreasing' in
     FigureFactory.create_candlestick()
 
-    :param (list) open: opening values
-    :param (list) high: high values
-    :param (list) low: low values
-    :param (list) close: closing values
-    :param (list) dates: list of datetime objects. Default: None
-    :param kwargs: kwargs to be passed to increasing trace via
+    Parameters
+    ----------
+    open : list
+        Opening values
+    high : list
+        High values
+    low : list
+        Low values
+    close : list
+        Closing values
+    dates : list 
+        List of datetime objects. Default: None
+    **kwargs :
+        kwargs to be passed to increasing trace via
         plotly.graph_objects.Scatter.
 
-    :rtype (list) candle_incr_data: list of the box trace for
-        increasing candlesticks.
+    Returns
+    -------
+    candle_incr_data : list
+        List of the box trace for increasing candlesticks.
     """
     increase_x, increase_y = _Candlestick(
         open, high, low, close, dates, **kwargs
@@ -59,16 +69,26 @@ def make_decreasing_candle(open, high, low, close, dates, **kwargs):
     """
     Makes boxplot trace for decreasing candlesticks
 
-    :param (list) open: opening values
-    :param (list) high: high values
-    :param (list) low: low values
-    :param (list) close: closing values
-    :param (list) dates: list of datetime objects. Default: None
-    :param kwargs: kwargs to be passed to decreasing trace via
+    Parameters
+    ----------
+    open : list
+        Opening values
+    high : list
+        High values
+    low : list
+        Low values
+    close : list
+        Closing values
+    dates : list 
+        List of datetime objects. Default: None
+    **kwargs :
+        kwargs to be passed to decreasing trace via
         plotly.graph_objects.Scatter.
 
-    :rtype (list) candle_decr_data: list of the box trace for
-        decreasing candlesticks.
+    Returns
+    -------
+    candle_decr_data : list 
+        List of the box trace for decreasing candlesticks.
     """
 
     decrease_x, decrease_y = _Candlestick(
@@ -97,15 +117,23 @@ def make_decreasing_candle(open, high, low, close, dates, **kwargs):
 
 def create_candlestick(open, high, low, close, dates=None, direction="both", **kwargs):
     """
-    **deprecated**, use instead the plotly.graph_objs trace
+    **Deprecated**, use instead the plotly.graph_objs trace
     :class:`plotly.graph_objs.Candlestick`
 
-    :param (list) open: opening values
-    :param (list) high: high values
-    :param (list) low: low values
-    :param (list) close: closing values
-    :param (list) dates: list of datetime objects. Default: None
-    :param (string) direction: direction can be 'increasing', 'decreasing',
+    Parameters
+    ----------
+    open : list
+        Opening values
+    high : list
+        High values
+    low : list
+        Low values
+    close : list
+        Closing values
+    dates : list 
+        List of datetime objects. Default: None
+    direction : str
+        Direction can be 'increasing', 'decreasing',
         or 'both'. When the direction is 'increasing', the returned figure
         consists of all candlesticks where the close value is greater than
         the corresponding open value, and when the direction is
@@ -113,13 +141,18 @@ def create_candlestick(open, high, low, close, dates=None, direction="both", **k
         where the close value is less than or equal to the corresponding
         open value. When the direction is 'both', both increasing and
         decreasing candlesticks are returned. Default: 'both'
-    :param kwargs: kwargs passed through plotly.graph_objects.Scatter.
+    **kwargs : 
+        kwargs passed through plotly.graph_objects.Scatter.
         These kwargs describe other attributes about the ohlc Scatter trace
         such as the color or the legend name. For more information on valid
         kwargs call help(plotly.graph_objects.Scatter)
 
-    :rtype (dict): returns a representation of candlestick chart figure.
+    Returns
+    -------
+    dict: a representation of candlestick chart figure.
 
+    Examples
+    --------
     Example 1: Simple candlestick chart from a Pandas DataFrame
 
     >>> from plotly.figure_factory import create_candlestick

--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -24,7 +24,7 @@ def create_dendrogram(
     Function that returns a dendrogram Plotly figure object. This is a thin
     wrapper around scipy.cluster.hierarchy.dendrogram.
 
-    See also https://dash.plot.ly/dash-bio/clustergram.
+    See also <https://dash.plotly.com/dash-bio/clustergram>.
 
     Parameters
     ----------

--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -26,24 +26,37 @@ def create_dendrogram(
 
     See also https://dash.plot.ly/dash-bio/clustergram.
 
-    :param (ndarray) X: Matrix of observations as array of arrays
-    :param (str) orientation: 'top', 'right', 'bottom', or 'left'
-    :param (list) labels: List of axis category labels(observation labels)
-    :param (list) colorscale: Optional colorscale for the dendrogram tree.
-                              Requires 8 colors to be specified, the 7th of
-                              which is ignored.  With scipy>=1.5.0, the 2nd, 3rd
-                              and 6th are used twice as often as the others.
-                              Given a shorter list, the missing values are
-                              replaced with defaults and with a longer list the
-                              extra values are ignored.
-    :param (function) distfun: Function to compute the pairwise distance from
-                               the observations
-    :param (function) linkagefun: Function to compute the linkage matrix from
-                               the pairwise distances
-    :param (list[list]) hovertext: List of hovertext for constituent traces of dendrogram
-                               clusters
-    :param (double) color_threshold: Value at which the separation of clusters will be made
+    Parameters
+    ----------
+    X : ndarray
+        Matrix of observations as array of arrays.
+    orientation : str
+        'top', 'right', 'bottom', or 'left'
+    labels : list
+        List of axis category labels(observation labels).
+    colorscale : list
+        Optional colorscale for the dendrogram tree.
+        Requires 8 colors to be specified, the 7th of
+        which is ignored.  With scipy>=1.5.0, the 2nd, 3rd
+        and 6th are used twice as often as the others.
+        Given a shorter list, the missing values are
+        replaced with defaults and with a longer list the
+        extra values are ignored.
+    distfun : function
+        Function to compute the pairwise distance from
+        the observations.
+    linkagefun : function
+        Function to compute the linkage matrix from
+        the pairwise distances.
+    hovertext : list[list]
+        List of hovertext for constituent traces of dendrogram
+        clusters.
+    color_threshold : double 
+        Value at which the separation of clusters will be made.
 
+
+    Examples
+    ---------
     Example 1: Simple bottom oriented dendrogram
 
     >>> from plotly.figure_factory import create_dendrogram

--- a/plotly/figure_factory/_distplot.py
+++ b/plotly/figure_factory/_distplot.py
@@ -62,11 +62,13 @@ def create_distplot(
     **this function is deprecated**, use instead :mod:`plotly.express`
     functions, for example
 
+    ```
     >>> import plotly.express as px
     >>> tips = px.data.tips()
     >>> fig = px.histogram(tips, x="total_bill", y="tip", color="sex", marginal="rug",
     ...                    hover_data=tips.columns)
     >>> fig.show()
+    ```
 
 
     The distplot can be composed of all or any combination of the following
@@ -74,21 +76,37 @@ def create_distplot(
     or (b) normal curve, and (3) rug plot. Additionally, multiple distplots
     (from multiple datasets) can be created in the same plot.
 
-    :param (list[list]) hist_data: Use list of lists to plot multiple data
-        sets on the same plot.
-    :param (list[str]) group_labels: Names for each data set.
-    :param (list[float]|float) bin_size: Size of histogram bins.
+    Parameters
+    ----------
+    hist_data : list[list]
+        Use list of lists to plot multiple data sets on the same plot.
+    group_labels : list[str]
+        Names for each data set.
+    bin_size : list[float] or float 
+        Size of histogram bins.
         Default = 1.
-    :param (str) curve_type: 'kde' or 'normal'. Default = 'kde'
-    :param (str) histnorm: 'probability density' or 'probability'
+    curve_type : str 
+        'kde' or 'normal'. Default = 'kde'
+    histnorm : str 
+        'probability density' or 'probability'
         Default = 'probability density'
-    :param (bool) show_hist: Add histogram to distplot? Default = True
-    :param (bool) show_curve: Add curve to distplot? Default = True
-    :param (bool) show_rug: Add rug to distplot? Default = True
-    :param (list[str]) colors: Colors for traces.
-    :param (list[list]) rug_text: Hovertext values for rug_plot,
-    :return (dict): Representation of a distplot figure.
+    show_hist : bool 
+        Add histogram to distplot? Default = True
+    show_curve : bool
+        Add curve to distplot? Default = True
+    show_rug : bool 
+        Add rug to distplot? Default = True
+    colors : list[str] 
+        Colors for traces.
+    rug_text : list[list] 
+        Hovertext values for rug_plot,
 
+    Returns
+    -------
+    dict: Representation of a distplot figure.
+
+    Examples
+    --------
     Example 1: Simple distplot of 1 data set
 
     >>> from plotly.figure_factory import create_distplot

--- a/plotly/figure_factory/_distplot.py
+++ b/plotly/figure_factory/_distplot.py
@@ -59,8 +59,8 @@ def create_distplot(
 ):
     """
     Function that creates a distplot similar to seaborn.distplot;
-    **this function is deprecated**, use instead :mod:`plotly.express`
-    functions, for example
+    **this function is deprecated**, use instead [`plotly.express`](/reference/plotly-express.md)
+    functions, for example:
 
     ```
     >>> import plotly.express as px

--- a/plotly/figure_factory/_facet_grid.py
+++ b/plotly/figure_factory/_facet_grid.py
@@ -668,9 +668,10 @@ def create_facet_grid(
     **kwargs,
 ):
     """
-    Returns figure for facet grid; **this function is deprecated**, since
+    **This function is deprecated**, since
     plotly.express functions should be used instead, for example
 
+    ```
     >>> import plotly.express as px
     >>> tips = px.data.tips()
     >>> fig = px.scatter(tips,
@@ -679,52 +680,80 @@ def create_facet_grid(
     ...     facet_row='sex',
     ...     facet_col='smoker',
     ...     color='size')
+    ```
 
-
-    :param (pd.DataFrame) df: the dataframe of columns for the facet grid.
-    :param (str) x: the name of the dataframe column for the x axis data.
-    :param (str) y: the name of the dataframe column for the y axis data.
-    :param (str) facet_row: the name of the dataframe column that is used to
+    Parameters
+    ----------
+    df : pd.DataFrame 
+        The dataframe of columns for the facet grid.
+    x : str 
+        The name of the dataframe column for the x axis data.
+    y : str 
+        The name of the dataframe column for the y axis data.
+    facet_row : str 
+        The name of the dataframe column that is used to
         facet the grid into row panels.
-    :param (str) facet_col: the name of the dataframe column that is used to
+    facet_col : str 
+        The name of the dataframe column that is used to
         facet the grid into column panels.
-    :param (str) color_name: the name of your dataframe column that will
+    color_name : str 
+        The name of your dataframe column that will
         function as the colormap variable.
-    :param (str|list|dict) colormap: the param that determines how the
+    colormap : str or list or dict 
+        The param that determines how the
         color_name column colors the data. If the dataframe contains numeric
         data, then a dictionary of colors will group the data categorically
         while a Plotly Colorscale name or a custom colorscale will treat it
         numerically. To learn more about colors and types of colormap, run
         `help(plotly.colors)`.
-    :param (bool) color_is_cat: determines whether a numerical column for the
+    color_is_cat : bool 
+        Determines whether a numerical column for the
         colormap will be treated as categorical (True) or sequential (False).
-            Default = False.
-    :param (str|dict) facet_row_labels: set to either 'name' or a dictionary
+        Default = False.
+    facet_row_labels : str or dict 
+        Set to either 'name' or a dictionary
         of all the unique values in the faceting row mapped to some text to
         show up in the label annotations. If None, labeling works like usual.
-    :param (str|dict) facet_col_labels: set to either 'name' or a dictionary
+    facet_col_labels : str or dict 
+        Set to either 'name' or a dictionary
         of all the values in the faceting row mapped to some text to show up
         in the label annotations. If None, labeling works like usual.
-    :param (int) height: the height of the facet grid figure.
-    :param (int) width: the width of the facet grid figure.
-    :param (str) trace_type: decides the type of plot to appear in the
+    height : int 
+        The height of the facet grid figure.
+    width : int 
+        The width of the facet grid figure.
+    trace_type : str 
+        Decides the type of plot to appear in the
         facet grid. The options are 'scatter', 'scattergl', 'histogram',
         'bar', and 'box'.
         Default = 'scatter'.
-    :param (str) scales: determines if axes have fixed ranges or not. Valid
+    scales : str 
+        Determines if axes have fixed ranges or not. Valid
         settings are 'fixed' (all axes fixed), 'free_x' (x axis free only),
         'free_y' (y axis free only) or 'free' (both axes free).
-    :param (float) dtick_x: determines the distance between each tick on the
+    dtick_x : float 
+        Determines the distance between each tick on the
         x-axis. Default is None which means dtick_x is set automatically.
-    :param (float) dtick_y: determines the distance between each tick on the
+    dtick_y : float 
+        Determines the distance between each tick on the
         y-axis. Default is None which means dtick_y is set automatically.
-    :param (bool) show_boxes: draws grey boxes behind the facet titles.
-    :param (bool) ggplot2: draws the facet grid in the style of `ggplot2`. See
+    show_boxes : bool 
+        Draws grey boxes behind the facet titles.
+    ggplot2 : bool 
+        Draws the facet grid in the style of `ggplot2`. See
         http://ggplot2.tidyverse.org/reference/facet_grid.html for reference.
         Default = False
-    :param (int) binsize: groups all data into bins of a given length.
-    :param (dict) kwargs: a dictionary of scatterplot arguments.
+    binsize : int 
+        Groups all data into bins of a given length.
+    **kwargs : dict 
+        A dictionary of scatterplot arguments.
 
+    Returns
+    -------
+    fig: for facet grid
+    
+    Examples
+    --------
     Examples 1: One Way Faceting
 
     >>> import plotly.figure_factory as ff

--- a/plotly/figure_factory/_facet_grid.py
+++ b/plotly/figure_factory/_facet_grid.py
@@ -741,7 +741,7 @@ def create_facet_grid(
         Draws grey boxes behind the facet titles.
     ggplot2 : bool 
         Draws the facet grid in the style of `ggplot2`. See
-        http://ggplot2.tidyverse.org/reference/facet_grid.html for reference.
+        <http://ggplot2.tidyverse.org/reference/facet_grid.html> for reference.
         Default = False
     binsize : int 
         Groups all data into bins of a given length.
@@ -750,7 +750,8 @@ def create_facet_grid(
 
     Returns
     -------
-    fig: for facet grid
+    fig: 
+        Of a facet grid
     
     Examples
     --------

--- a/plotly/figure_factory/_gantt.py
+++ b/plotly/figure_factory/_gantt.py
@@ -817,18 +817,20 @@ def create_gantt(
     show_hover_fill=True,
 ):
     """
-    **deprecated**, use instead
+    **Deprecated**, use instead
     :func:`plotly.express.timeline`.
 
-    Returns figure for a gantt chart
-
-    :param (array|list) df: input data for gantt chart. Must be either a
+    Parameters
+    ----------
+    df : array or list 
+        Input data for gantt chart. Must be either a
         a dataframe or a list. If dataframe, the columns must include
         'Task', 'Start' and 'Finish'. Other columns can be included and
         used for indexing. If a list, its elements must be dictionaries
         with the same required column headers: 'Task', 'Start' and
         'Finish'.
-    :param (str|list|dict|tuple) colors: either a plotly scale name, an
+    colors : str or list or dict or tuple 
+        Either a plotly scale name, an
         rgb or hex color, a color tuple or a list of colors. An rgb color
         is of the form 'rgb(x, y, z)' where x, y, z belong to the interval
         [0, 255] and a color tuple is a tuple of the form (a, b, c) where
@@ -836,21 +838,37 @@ def create_gantt(
         contain the valid color types aforementioned as its members.
         If a dictionary, all values of the indexing column must be keys in
         colors.
-    :param (str|float) index_col: the column header (if df is a data
+    index_col : str or float 
+        The column header (if df is a data
         frame) that will function as the indexing column. If df is a list,
         index_col must be one of the keys in all the items of df.
-    :param (bool) show_colorbar: determines if colorbar will be visible.
+    show_colorbar : bool 
+        Determines if colorbar will be visible.
         Only applies if values in the index column are numeric.
-    :param (bool) show_hover_fill: enables/disables the hovertext for the
+    show_hover_fill : bool 
+        Enables/disables the hovertext for the
         filled area of the chart.
-    :param (bool) reverse_colors: reverses the order of selected colors
-    :param (str) title: the title of the chart
-    :param (float) bar_width: the width of the horizontal bars in the plot
-    :param (bool) showgrid_x: show/hide the x-axis grid
-    :param (bool) showgrid_y: show/hide the y-axis grid
-    :param (float) height: the height of the chart
-    :param (float) width: the width of the chart
+    reverse_colors : bool 
+        Reverses the order of selected colors
+    title : str
+        The title of the chart
+    bar_width : float 
+        The width of the horizontal bars in the plot
+    showgrid_x : bool 
+        Show/hide the x-axis grid
+    showgrid_y : bool 
+        Show/hide the y-axis grid
+    height : float 
+        The height of the chart
+    width : float 
+        The width of the chart
 
+    Returns
+    -------
+    fig: for a gantt chart
+
+    Examples
+    --------
     Example 1: Simple Gantt Chart
 
     >>> from plotly.figure_factory import create_gantt

--- a/plotly/figure_factory/_gantt.py
+++ b/plotly/figure_factory/_gantt.py
@@ -818,7 +818,7 @@ def create_gantt(
 ):
     """
     **Deprecated**, use instead
-    :func:`plotly.express.timeline`.
+    [`plotly.express.timeline`](/reference/plotly-express.md#plotly.express.timeline).
 
     Parameters
     ----------
@@ -865,7 +865,8 @@ def create_gantt(
 
     Returns
     -------
-    fig: for a gantt chart
+    fig: 
+        Of a gantt chart
 
     Examples
     --------

--- a/plotly/figure_factory/_ohlc.py
+++ b/plotly/figure_factory/_ohlc.py
@@ -132,15 +132,23 @@ def make_decreasing_ohlc(open, high, low, close, dates, **kwargs):
 
 def create_ohlc(open, high, low, close, dates=None, direction="both", **kwargs):
     """
-    **deprecated**, use instead the plotly.graph_objs trace
+    **Deprecated**, use instead the plotly.graph_objs trace
     :class:`plotly.graph_objs.Ohlc`
 
-    :param (list) open: opening values
-    :param (list) high: high values
-    :param (list) low: low values
-    :param (list) close: closing
-    :param (list) dates: list of datetime objects. Default: None
-    :param (string) direction: direction can be 'increasing', 'decreasing',
+    Parameters
+    ----------
+    open : list 
+        Opening values
+    high : list 
+        High values
+    low : list 
+        Low values
+    close : list 
+        Closing values
+    dates : list 
+        List of datetime objects. Default: None
+    direction : str 
+        Direction can be 'increasing', 'decreasing',
         or 'both'. When the direction is 'increasing', the returned figure
         consists of all units where the close value is greater than the
         corresponding open value, and when the direction is 'decreasing',
@@ -148,13 +156,18 @@ def create_ohlc(open, high, low, close, dates=None, direction="both", **kwargs):
         less than or equal to the corresponding open value. When the
         direction is 'both', both increasing and decreasing units are
         returned. Default: 'both'
-    :param kwargs: kwargs passed through plotly.graph_objects.Scatter.
+    **kwargs: 
+        kwargs passed through plotly.graph_objects.Scatter.
         These kwargs describe other attributes about the ohlc Scatter trace
         such as the color or the legend name. For more information on valid
         kwargs call help(plotly.graph_objects.Scatter)
+    
+    Returns
+    -------
+    dict: a representation of an ohlc chart figure.
 
-    :rtype (dict): returns a representation of an ohlc chart figure.
-
+    Examples
+    --------
     Example 1: Simple OHLC chart from a Pandas DataFrame
 
     >>> from plotly.figure_factory import create_ohlc

--- a/plotly/figure_factory/_ohlc.py
+++ b/plotly/figure_factory/_ohlc.py
@@ -132,8 +132,8 @@ def make_decreasing_ohlc(open, high, low, close, dates, **kwargs):
 
 def create_ohlc(open, high, low, close, dates=None, direction="both", **kwargs):
     """
-    **Deprecated**, use instead the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Ohlc`
+    **Deprecated**, use instead the plotly.graph_objects trace
+    [`plotly.graph_objects.Ohlc`](/reference/graph_objects/Ohlc.md)
 
     Parameters
     ----------
@@ -164,7 +164,8 @@ def create_ohlc(open, high, low, close, dates=None, direction="both", **kwargs):
     
     Returns
     -------
-    dict: a representation of an ohlc chart figure.
+    dict 
+        A representation of an ohlc chart figure.
 
     Examples
     --------

--- a/plotly/figure_factory/_quiver.py
+++ b/plotly/figure_factory/_quiver.py
@@ -40,7 +40,8 @@ def create_quiver(
 
     Returns
     -------
-    dict: a representation of quiver figure.
+    dict 
+        A representation of quiver figure.
 
     Examples
     --------

--- a/plotly/figure_factory/_quiver.py
+++ b/plotly/figure_factory/_quiver.py
@@ -11,24 +11,39 @@ def create_quiver(
     """
     Returns data for a quiver plot.
 
-    :param (list|ndarray) x: x coordinates of the arrow locations
-    :param (list|ndarray) y: y coordinates of the arrow locations
-    :param (list|ndarray) u: x components of the arrow vectors
-    :param (list|ndarray) v: y components of the arrow vectors
-    :param (float in [0,1]) scale: scales size of the arrows(ideally to
+    Parameters
+    ----------
+    x : list or ndarray 
+        x coordinates of the arrow locations
+    y : list or ndarray 
+        y coordinates of the arrow locations
+    u : list or ndarray 
+        x components of the arrow vectors
+    v : list or ndarray 
+        y components of the arrow vectors
+    scale : float in [0,1] 
+        Scales size of the arrows(ideally to
         avoid overlap). Default = .1
-    :param (float in [0,1]) arrow_scale: value multiplied to length of barb
+    arrow_scale : float in [0,1] 
+        Value multiplied to length of barb
         to get length of arrowhead. Default = .3
-    :param (angle in radians) angle: angle of arrowhead. Default = pi/9
-    :param (positive float) scaleratio: the ratio between the scale of the y-axis
+    angle : radians 
+        Angle of arrowhead. Default = pi/9
+    scaleratio : positive float 
+        The ratio between the scale of the y-axis
         and the scale of the x-axis (scale_y / scale_x). Default = None, the
         scale ratio is not fixed.
-    :param kwargs: kwargs passed through plotly.graph_objects.Scatter
+    **kwargs: 
+        kwargs passed through plotly.graph_objects.Scatter
         for more information on valid kwargs call
         help(plotly.graph_objects.Scatter)
 
-    :rtype (dict): returns a representation of quiver figure.
+    Returns
+    -------
+    dict: a representation of quiver figure.
 
+    Examples
+    --------
     Example 1: Trivial Quiver
 
     >>> from plotly.figure_factory import create_quiver

--- a/plotly/figure_factory/_scatterplot.py
+++ b/plotly/figure_factory/_scatterplot.py
@@ -851,8 +851,8 @@ def create_scatterplotmatrix(
 ):
     """
     **Deprecated**,
-    use instead the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Splom`.
+    use instead the plotly.graph_objects trace
+    [`plotly.graph_objects.Splom`](/reference/graph_objects/Splom.md).
 
     Parameters
     ----------
@@ -904,7 +904,8 @@ def create_scatterplotmatrix(
 
     Returns
     -------
-    fig : data for a scatterplot matrix
+    fig:
+        Data for a scatterplot matrix
 
     Examples
     --------

--- a/plotly/figure_factory/_scatterplot.py
+++ b/plotly/figure_factory/_scatterplot.py
@@ -850,24 +850,34 @@ def create_scatterplotmatrix(
     **kwargs,
 ):
     """
-    Returns data for a scatterplot matrix;
-    **deprecated**,
+    **Deprecated**,
     use instead the plotly.graph_objs trace
     :class:`plotly.graph_objs.Splom`.
 
-    :param (array) df: array of the data with column headers
-    :param (str) index: name of the index column in data array
-    :param (list|tuple) endpts: takes an increasing sequece of numbers
+    Parameters
+    ----------
+    df : array 
+        Array of the data with column headers
+    index : str 
+        Name of the index column in data array
+    endpts : list or tuple 
+        Takes an increasing sequece of numbers
         that defines intervals on the real line. They are used to group
         the entries in an index of numbers into their corresponding
         interval and therefore can be treated as categorical data
-    :param (str) diag: sets the chart type for the main diagonal plots.
+    diag : str 
+        Sets the chart type for the main diagonal plots.
         The options are 'scatter', 'histogram' and 'box'.
-    :param (int|float) height: sets the height of the chart
-    :param (int|float) width: sets the width of the chart
-    :param (float) size: sets the marker size (in px)
-    :param (str) title: the title label of the scatterplot matrix
-    :param (str|tuple|list|dict) colormap: either a plotly scale name,
+    height : int or float
+        Sets the height of the chart
+    width : int or float 
+        Sets the width of the chart
+    size : float 
+        Sets the marker size (in px)
+    title : str t
+        The title label of the scatterplot matrix
+    colormap : str or tuple or list or dict 
+        Either a plotly scale name,
         an rgb or hex color, a color tuple, a list of colors or a
         dictionary. An rgb color is of the form 'rgb(x, y, z)' where
         x, y and z belong to the interval [0, 255] and a color tuple is a
@@ -877,7 +887,8 @@ def create_scatterplotmatrix(
         If colormap is a dictionary, all the string entries in
         the index column must be a key in colormap. In this case, the
         colormap_type is forced to 'cat' or categorical
-    :param (str) colormap_type: determines how colormap is interpreted.
+    colormap_type : str    
+        Determines how colormap is interpreted.
         Valid choices are 'seq' (sequential) and 'cat' (categorical). If
         'seq' is selected, only the first two colors in colormap will be
         considered (when colormap is a list) and the index values will be
@@ -886,10 +897,17 @@ def create_scatterplotmatrix(
         If 'cat' is selected, a color from colormap will be assigned to
         each category from index, including the intervals if endpts is
         being used
-    :param (dict) **kwargs: a dictionary of scatterplot arguments
+    **kwargs : 
+        a dictionary of scatterplot arguments
         The only forbidden parameters are 'size', 'color' and
         'colorscale' in 'marker'
 
+    Returns
+    -------
+    fig : data for a scatterplot matrix
+
+    Examples
+    --------
     Example 1: Vanilla Scatterplot Matrix
 
     >>> from plotly.graph_objects import graph_objects

--- a/plotly/figure_factory/_streamline.py
+++ b/plotly/figure_factory/_streamline.py
@@ -40,23 +40,37 @@ def create_streamline(
     """
     Returns data for a streamline plot.
 
-    :param (list|ndarray) x: 1 dimensional, evenly spaced list or array
-    :param (list|ndarray) y: 1 dimensional, evenly spaced list or array
-    :param (ndarray) u: 2 dimensional array
-    :param (ndarray) v: 2 dimensional array
-    :param (float|int) density: controls the density of streamlines in
+    Parameters
+    ----------
+    x : list or ndarray 
+        1 dimensional, evenly spaced list or array
+    y : list or ndarray 
+        1 dimensional, evenly spaced list or array
+    u : ndarray
+        2 dimensional array
+    v : ndarray 
+        2 dimensional array
+    density : float or int 
+        Controls the density of streamlines in
         plot. This is multiplied by 30 to scale similiarly to other
         available streamline functions such as matplotlib.
         Default = 1
-    :param (angle in radians) angle: angle of arrowhead. Default = pi/9
-    :param (float in [0,1]) arrow_scale: value to scale length of arrowhead
+    angle : radians 
+        Angle of arrowhead. Default = pi/9
+    arrow_scale : float in [0,1] 
+        Value to scale length of arrowhead
         Default = .09
-    :param kwargs: kwargs passed through plotly.graph_objects.Scatter
+    **kwargs: 
+        kwargs passed through plotly.graph_objects.Scatter
         for more information on valid kwargs call
         help(plotly.graph_objects.Scatter)
 
-    :rtype (dict): returns a representation of streamline figure.
+    Returns
+    -------
+    dict: a representation of streamline figure.
 
+    Examples
+    --------
     Example 1: Plot simple streamline and increase arrow size
 
     >>> from plotly.figure_factory import create_streamline

--- a/plotly/figure_factory/_streamline.py
+++ b/plotly/figure_factory/_streamline.py
@@ -67,7 +67,8 @@ def create_streamline(
 
     Returns
     -------
-    dict: a representation of streamline figure.
+    dict
+        A representation of streamline figure.
 
     Examples
     --------

--- a/plotly/figure_factory/_table.py
+++ b/plotly/figure_factory/_table.py
@@ -39,25 +39,36 @@ def create_table(
     See also the plotly.graph_objs trace
     :class:`plotly.graph_objs.Table`
 
-    :param (pandas.Dataframe | list[list]) text: data for table.
-    :param (str|list[list]) colorscale: Colorscale for table where the
+    Parameters
+    ----------
+    text : pandas.Dataframe or list[list]
+        Data for table.
+    colorscale : str or list[list]
+        Colorscale for table where the
         color at value 0 is the header color, .5 is the first table color
         and 1 is the second table color. (Set .5 and 1 to avoid the striped
         table effect). Default=[[0, '#66b2ff'], [.5, '#d9d9d9'],
         [1, '#ffffff']]
-    :param (list) font_colors: Color for fonts in table. Can be a single
+    font_colors : list 
+        Color for fonts in table. Can be a single
         color, three colors, or a color for each row in the table.
         Default=['#000000'] (black text for the entire table)
-    :param (int) height_constant: Constant multiplied by # of rows to
+    height_constant : int 
+        Constant multiplied by # of rows to
         create table height. Default=30.
-    :param (bool) index: Create (header-colored) index column index from
+    index : bool 
+        Create (header-colored) index column index from
         Pandas dataframe or list[0] for each list in text. Default=False.
-    :param (string) index_title: Title for index column. Default=''.
-    :param kwargs: kwargs passed through plotly.graph_objects.Heatmap.
+    index_title : str 
+        Title for index column. Default=''.
+    **kwargs: 
+        kwargs passed through plotly.graph_objects.Heatmap.
         These kwargs describe other attributes about the annotated Heatmap
         trace such as the colorscale. For more information on valid kwargs
         call help(plotly.graph_objects.Heatmap)
 
+    Examples
+    --------
     Example 1: Simple Plotly Table
 
     >>> from plotly.figure_factory import create_table

--- a/plotly/figure_factory/_table.py
+++ b/plotly/figure_factory/_table.py
@@ -36,8 +36,8 @@ def create_table(
     """
     Function that creates data tables.
 
-    See also the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Table`
+    See also the plotly.graph_objects trace
+    [`plotly.graph_objects.Table`](/reference/graph_objects/Table.md)
 
     Parameters
     ----------

--- a/plotly/figure_factory/_trisurf.py
+++ b/plotly/figure_factory/_trisurf.py
@@ -324,7 +324,8 @@ def create_trisurf(
     
     Returns
     -------
-    fig: of a triangulated surface plot
+    fig : 
+        Of a triangulated surface plot
 
     Examples
     --------

--- a/plotly/figure_factory/_trisurf.py
+++ b/plotly/figure_factory/_trisurf.py
@@ -265,43 +265,69 @@ def create_trisurf(
     """
     Returns figure for a triangulated surface plot
 
-    :param (array) x: data values of x in a 1D array
-    :param (array) y: data values of y in a 1D array
-    :param (array) z: data values of z in a 1D array
-    :param (array) simplices: an array of shape (ntri, 3) where ntri is
+    Parameters
+    ----------
+    x : array 
+        Data values of x in a 1D array
+    y : array
+        Data values of y in a 1D array
+    z : array 
+        Data values of z in a 1D array
+    simplices : array 
+        An array of shape (ntri, 3) where ntri is
         the number of triangles in the triangularization. Each row of the
         array contains the indicies of the verticies of each triangle
-    :param (str|tuple|list) colormap: either a plotly scale name, an rgb
+    colormap : str or tuple or list 
+        Either a plotly scale name, an rgb
         or hex color, a color tuple or a list of colors. An rgb color is
         of the form 'rgb(x, y, z)' where x, y, z belong to the interval
         [0, 255] and a color tuple is a tuple of the form (a, b, c) where
         a, b and c belong to [0, 1]. If colormap is a list, it must
         contain the valid color types aforementioned as its members
-    :param (bool) show_colorbar: determines if colorbar is visible
-    :param (list|array) scale: sets the scale values to be used if a non-
+    show_colorbar : bool 
+        Determines if colorbar is visible
+    scale : list or array 
+        Sets the scale values to be used if a non-
         linearly interpolated colormap is desired. If left as None, a
         linear interpolation between the colors will be excecuted
-    :param (function|list) color_func: The parameter that determines the
+    color_func : function or list 
+        The parameter that determines the
         coloring of the surface. Takes either a function with 3 arguments
         x, y, z or a list/array of color values the same length as
         simplices. If None, coloring will only depend on the z axis
-    :param (str) title: title of the plot
-    :param (bool) plot_edges: determines if the triangles on the trisurf
+    title : str 
+        Title of the plot
+    plot_edges : bool 
+        Determines if the triangles on the trisurf
         are visible
-    :param (bool) showbackground: makes background in plot visible
-    :param (str) backgroundcolor: color of background. Takes a string of
+    showbackground : bool 
+        Makes background in plot visible
+    backgroundcolor : str 
+        Color of background. Takes a string of
         the form 'rgb(x,y,z)' x,y,z are between 0 and 255 inclusive
-    :param (str) gridcolor: color of the gridlines besides the axes. Takes
+    gridcolor : str
+        Color of the gridlines besides the axes. Takes
         a string of the form 'rgb(x,y,z)' x,y,z are between 0 and 255
         inclusive
-    :param (str) zerolinecolor: color of the axes. Takes a string of the
+    zerolinecolor : str 
+        Color of the axes. Takes a string of the
         form 'rgb(x,y,z)' x,y,z are between 0 and 255 inclusive
-    :param (str) edges_color: color of the edges, if plot_edges is True
-    :param (int|float) height: the height of the plot (in pixels)
-    :param (int|float) width: the width of the plot (in pixels)
-    :param (dict) aspectratio: a dictionary of the aspect ratio values for
+    edges_color : str 
+        Color of the edges, if plot_edges is True
+    height : int or float 
+        The height of the plot (in pixels)
+    width : int or float 
+        The width of the plot (in pixels)
+    aspectratio : dict 
+        A dictionary of the aspect ratio values for
         the x, y and z axes. 'x', 'y' and 'z' take (int|float) values
+    
+    Returns
+    -------
+    fig: of a triangulated surface plot
 
+    Examples
+    --------
     Example 1: Sphere
 
     >>> # Necessary Imports for Trisurf

--- a/plotly/figure_factory/_violin.py
+++ b/plotly/figure_factory/_violin.py
@@ -443,8 +443,8 @@ def create_violin(
     title="Violin and Rug Plot",
 ):
     """
-    **Deprecated**, use instead the plotly.graph_objs trace
-    :class:`plotly.graph_objs.Violin`.
+    **Deprecated**, use instead the plotly.graph_objects trace
+    [`plotly.graph_objects.Violin`](/reference/graph_objects/Violin.md).
 
     Parameters
     ----------

--- a/plotly/figure_factory/_violin.py
+++ b/plotly/figure_factory/_violin.py
@@ -443,42 +443,58 @@ def create_violin(
     title="Violin and Rug Plot",
 ):
     """
-    **deprecated**, use instead the plotly.graph_objs trace
+    **Deprecated**, use instead the plotly.graph_objs trace
     :class:`plotly.graph_objs.Violin`.
 
-    :param (list|array) data: accepts either a list of numerical values,
+    Parameters
+    ----------
+    data : list or array 
+        Accepts either a list of numerical values,
         a list of dictionaries all with identical keys and at least one
         column of numeric values, or a pandas dataframe with at least one
         column of numbers.
-    :param (str) data_header: the header of the data column to be used
+    data_header : str 
+        The header of the data column to be used
         from an inputted pandas dataframe. Not applicable if 'data' is
         a list of numeric values.
-    :param (str) group_header: applicable if grouping data by a variable.
+    group_header : str 
+        Applicable if grouping data by a variable.
         'group_header' must be set to the name of the grouping variable.
-    :param (str|tuple|list|dict) colors: either a plotly scale name,
+    colors : str or tuple or list or dict
+        Either a plotly scale name,
         an rgb or hex color, a color tuple, a list of colors or a
         dictionary. An rgb color is of the form 'rgb(x, y, z)' where
         x, y and z belong to the interval [0, 255] and a color tuple is a
         tuple of the form (a, b, c) where a, b and c belong to [0, 1].
         If colors is a list, it must contain valid color types as its
         members.
-    :param (bool) use_colorscale: only applicable if grouping by another
+    use_colorscale : bool 
+        Only applicable if grouping by another
         variable. Will implement a colorscale based on the first 2 colors
         of param colors. This means colors must be a list with at least 2
         colors in it (Plotly colorscales are accepted since they map to a
         list of two rgb colors). Default = False
-    :param (dict) group_stats: a dictionary where each key is a unique
+    group_stats : dict 
+        A dictionary where each key is a unique
         value from the group_header column in data. Each value must be a
         number and will be used to color the violin plots if a colorscale
         is being used.
-    :param (bool) rugplot: determines if a rugplot is draw on violin plot.
+    rugplot : bool 
+        Determines if a rugplot is draw on violin plot.
         Default = True
-    :param (bool) sort: determines if violins are sorted
+    sort : bool 
+        Determines if violins are sorted
         alphabetically (True) or by input order (False). Default = False
-    :param (float) height: the height of the violin plot.
-    :param (float) width: the width of the violin plot.
-    :param (str) title: the title of the violin plot.
+    height : float 
+        The height of the violin plot.
+    width: float 
+        The width of the violin plot.
+    title : str
+        The title of the violin plot.
 
+
+    Examples
+    --------
     Example 1: Single Violin Plot
 
     >>> from plotly.figure_factory import create_violin

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -114,7 +114,7 @@ def to_html(
     animation_opts: dict or None (default None)
         dict of custom animation parameters to be passed to the function
         Plotly.animate in Plotly.js. See
-        https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
+        <https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js>
         for available options. Has no effect if the figure does not contain
         frames, or auto_play is False.
     default_width, default_height: number or str (default '100%')
@@ -446,7 +446,7 @@ def write_html(
     animation_opts: dict or None (default None)
         dict of custom animation parameters to be passed to the function
         Plotly.animate in Plotly.js. See
-        https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
+        <https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js>
         for available options. Has no effect if the figure does not contain
         frames, or auto_play is False.
     default_width, default_height: number or str (default '100%')


### PR DESCRIPTION
- Changed the docstring style into numpy. Most of the changes were made in `plotly/figure_factory/` and throughout some of the functions in the other `plotly/` modules.
- Fixed link rendering in the docstring of functions, so they render as actual links in markdown.
- Converted any references to internal pages into internal links (ie. `:func: plotly.express.density_heatmap` is now an internal reference)
- Minor grammar fixes for readability and to adjust to the new numpy style for docstrings.

Closes #58 