### PR TITLE
Add plotly studio image to navigation bar

### DIFF
--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -1,33 +1,4 @@
-/* Plotly Custom Colors */
-
-/* Define the custom primary color scheme */
-[data-md-color-primary="custom"] {
-    --md-primary-fg-color: #6E56CF;
-    --md-primary-fg-color--light: #8B72D9;
-    --md-primary-fg-color--dark: #5A47B8;
-    --md-primary-bg-color: #FFFFFF;
-    --md-primary-bg-color--light: #F8F7FD;
-  }
-  
-  /* Define the custom accent color scheme */
-  [data-md-color-accent="custom"] {
-    --md-accent-fg-color: #6E56CF;
-    --md-accent-fg-color--transparent: rgba(110, 86, 207, 0.1);
-    --md-accent-bg-color: #FFFFFF;
-    --md-accent-bg-color--light: #F8F7FD;
-  }
-  
-  /* Additional custom properties for consistency */
-  :root {
-    --md-primary-fg-color: orange;
-    --plotly-primary: #6E56CF;
-    --plotly-primary-light: #8B72D9;
-    --plotly-primary-dark: #5A47B8;
-    --plotly-primary-alpha-10: rgba(110, 86, 207, 0.1);
-    --plotly-primary-alpha-20: rgba(110, 86, 207, 0.2);
-  }
-  
-  pre[hide_code="true"] {
+pre[hide_code="true"] {
     display: none;
 }
   
@@ -54,4 +25,8 @@
     height: auto !important;
     width: 100%;
     object-fit: contain;
+}
+
+.nav-bottom-image a::after {
+  content: none !important;
 }

--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -34,3 +34,24 @@
 .maplibregl-control-container {
   display: none;
 }
+
+.md-nav--primary {
+    position: relative; 
+    display: flex; 
+    flex-direction: column;
+}
+
+.nav-bottom-image{
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background: var(--md-default-bg-color);
+    padding: 30px 25px 0px 25px;
+    height: 12.1rem;
+}
+
+.nav-bottom-image img{
+    height: auto !important;
+    width: 100%;
+    object-fit: contain;
+}

--- a/pages/overrides/main.html
+++ b/pages/overrides/main.html
@@ -1,5 +1,52 @@
 {% extends "base.html" %}
 
+{% block site_nav %}
+
+  <!-- Main navigation -->
+  {% if nav %}
+    {% if page and page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--primary"
+      data-md-component="sidebar"
+      data-md-type="navigation"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/nav.html" %}
+        </div>
+
+        <div class="nav-bottom-image">
+            <a href="https://plotly.com/webinars/data-apps-publishing-playbook/?utm_medium=graphing_libraries&utm_campaign=plotly_publishing_playbook&utm_content=sidebar" target="_blank">
+                <img src="https://images.prismic.io/plotly-marketing-website-2/aNMW2J5xUNkB1CWg_PlotlyPublishingPlaybook.jpg?auto=format,compress" alt="plotly-studio-banner" type="image/avif">
+            </a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <!-- Table of contents -->
+  {% if not "toc.integrate" in features %}
+    {% if page and page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "toc" in page.meta.hide %}
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--secondary"
+      data-md-component="sidebar"
+      data-md-type="toc"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/toc.html" %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 <blockquote>
     <p><strong>Plotly Studio:</strong> Transform any dataset into an interactive data application in minutes with AI. <a


### PR DESCRIPTION
- Added plotly studio ad image to the bottom of the left navigation bar.
- Cleaned up `plotly-style.css` by removing styling that isn't needed.
