### PR TITLE
Adjust styling and format

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,56 +236,56 @@ nav:
         - Image: reference/graph_objects/Image.md
         - Pie: reference/graph_objects/Pie.md
         - Scatter: reference/graph_objects/Scatter.md
-        - Scattergl: reference/graph_objects/Scattergl.md
+        - Scatter GL: reference/graph_objects/Scattergl.md
         - Table: reference/graph_objects/Table.md
       - Distribution Traces:
         - Box: reference/graph_objects/Box.md
         - Histogram: reference/graph_objects/Histogram.md
-        - Histogram2d: reference/graph_objects/Histogram2d.md
-        - Histogram2dContour: reference/graph_objects/Histogram2dContour.md
+        - Histogram 2D: reference/graph_objects/Histogram2d.md
+        - Histogram 2D Contour: reference/graph_objects/Histogram2dContour.md
         - Violin: reference/graph_objects/Violin.md
       - Finance Traces:
         - Candlestick: reference/graph_objects/Candlestick.md
         - Funnel: reference/graph_objects/Funnel.md
-        - Funnelarea: reference/graph_objects/Funnelarea.md
+        - Funnel Area: reference/graph_objects/Funnelarea.md
         - Indicator: reference/graph_objects/Indicator.md
-        - Ohlc: reference/graph_objects/Ohlc.md
+        - OHLC: reference/graph_objects/Ohlc.md
         - Waterfall: reference/graph_objects/Waterfall.md
       - 3D Traces:
         - Cone: reference/graph_objects/Cone.md
         - Isosurface: reference/graph_objects/Isosurface.md
-        - Mesh3d: reference/graph_objects/Mesh3d.md
-        - Scatter3d: reference/graph_objects/Scatter3d.md
+        - Mesh 3D: reference/graph_objects/Mesh3d.md
+        - Scatter 3D: reference/graph_objects/Scatter3d.md
         - Streamtube: reference/graph_objects/Streamtube.md
         - Surface: reference/graph_objects/Surface.md
         - Volume: reference/graph_objects/Volume.md
       - Map Traces:
         - Choropleth: reference/graph_objects/Choropleth.md
-        - Choroplethmap: reference/graph_objects/Choroplethmap.md
-        - Choroplethmapbox: reference/graph_objects/Choroplethmapbox.md
-        - Densitymap: reference/graph_objects/Densitymap.md
-        - Densitymapbox: reference/graph_objects/Densitymapbox.md
-        - Scattergeo: reference/graph_objects/Scattergeo.md
-        - Scattermap: reference/graph_objects/Scattermap.md
-        - Scattermapbox: reference/graph_objects/Scattermapbox.md
+        - Choropleth Map: reference/graph_objects/Choroplethmap.md
+        - Choropleth Mapbox: reference/graph_objects/Choroplethmapbox.md
+        - Density Map: reference/graph_objects/Densitymap.md
+        - Density Mapbox: reference/graph_objects/Densitymapbox.md
+        - Scatter Geo: reference/graph_objects/Scattergeo.md
+        - Scatter Map: reference/graph_objects/Scattermap.md
+        - Scatter Mapbox: reference/graph_objects/Scattermapbox.md
       - Specialized Traces:
         - Barpolar: reference/graph_objects/Barpolar.md
         - Carpet: reference/graph_objects/Carpet.md
-        - Contourcarpet: reference/graph_objects/Contourcarpet.md
+        - Contour Carpet: reference/graph_objects/Contourcarpet.md
         - Icicle: reference/graph_objects/Icicle.md
-        - Parcats: reference/graph_objects/Parcats.md
-        - Parcoords: reference/graph_objects/Parcoords.md
+        - Parallel Categories: reference/graph_objects/Parcats.md
+        - Parallel Coordinates: reference/graph_objects/Parcoords.md
         - Sankey: reference/graph_objects/Sankey.md
-        - Scattercarpet: reference/graph_objects/Scattercarpet.md
-        - Scatterpolar: reference/graph_objects/Scatterpolar.md
-        - Scatterpolargl: reference/graph_objects/Scatterpolargl.md
-        - Scattersmith: reference/graph_objects/Scattersmith.md
-        - Scatterternary: reference/graph_objects/Scatterternary.md
-        - Splom: reference/graph_objects/Splom.md
+        - Scatter Carpet: reference/graph_objects/Scattercarpet.md
+        - Scatter Polar: reference/graph_objects/Scatterpolar.md
+        - Scatter Polar GL: reference/graph_objects/Scatterpolargl.md
+        - Scatter Smith: reference/graph_objects/Scattersmith.md
+        - Scatter Ternary: reference/graph_objects/Scatterternary.md
+        - SPLOM: reference/graph_objects/Splom.md
         - Sunburst: reference/graph_objects/Sunburst.md
         - Treemap: reference/graph_objects/Treemap.md
       - Other Classes:
-        - FigureWidget: reference/graph_objects/FigureWidget.md
+        - Figure Widget: reference/graph_objects/FigureWidget.md
         - Frame: reference/graph_objects/Frame.md
       - Modules:
         - bar: reference/graph_objects/bar-package/index.md

--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -6,6 +6,8 @@ pre[hide_code="true"] {
   display: none;
 }
 
+/* Navigation Styling */
+
 .md-nav--primary {
     position: relative; 
     display: flex; 
@@ -18,7 +20,7 @@ pre[hide_code="true"] {
     z-index: 10;
     background: var(--md-default-bg-color);
     padding: 30px 25px 0px 25px;
-    height: 12.1rem;
+    /* height: 12.1rem; */
 }
 
 .nav-bottom-image img{
@@ -29,4 +31,158 @@ pre[hide_code="true"] {
 
 .nav-bottom-image a::after {
   content: none !important;
+}
+
+/* Footer Styling */
+
+.--footer-top {
+    -webkit-box-flex: 0;
+    padding: 20px;
+    width: 100%;
+}
+
+.--footer-column h6 {
+    /* color: #3f3f3f; */
+    position: relative;
+    margin: 0;
+    padding-bottom: 15px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    padding-top: 20px;
+    display: block;
+    font-weight: bold !important;
+}
+
+.md-footer {
+    background-color: var(--md-default-bg-color);
+}
+
+.md-footer ul{
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+.--footer-body {
+    -webkit-box-flex: 0;
+    display: flex;
+    list-style: none;
+    flex-wrap: wrap;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    margin-bottom: 10px;
+}
+.--footer-column {
+    -webkit-box-flex: 1;
+    flex: 1 1 20%;
+    padding: 10px;
+    min-width: 125px;
+}
+
+.--footer-column ul a {
+    color: #626262;
+    display: inline-block;
+    margin: 2px 0;
+}
+
+.--footer-column ul a::after {
+    display: none;
+}
+
+.--footer-column ul a:link:not(.button){
+    position: relative;
+    opacity: 0.95;
+    font-weight: 400;
+    color: #3f3f3f;
+    font-size: 14px;
+}
+
+
+@media screen and (max-width:1023px){
+    .--footer-column {
+        -webkit-box-flex: 1;
+        flex: 1 1 33.3333%;
+        max-width: 33.3333%;
+    }
+}
+
+@media screen and (min-width: 1200px){
+    .--footer-body {
+        flex-wrap: nowrap;
+    }
+}
+
+.subscribe-text {
+    margin-block-start: 0em;
+    font-size: 100%;
+    color: #626262;
+}
+
+.subscribe-button {
+    background-color: #2186f4;
+    border-radius: 1.22rem;
+    color: #fff !important;
+    cursor: pointer;
+    font-style: italic;
+    font-size: 12.8px;
+    line-height: 1.2;
+    letter-spacing: 1.33px;
+    outline: none;
+    padding: .35rem .72rem;
+    text-align: center;
+    text-decoration: none;
+    text-transform: uppercase;
+    transition: background-color .2s ease-in-out;
+}
+
+.--footer-meta {
+    -webkit-box-flex: 0;
+    padding: 20px;
+    font-size: 0.65rem;
+    font-weight: 400;
+    width: 100%;
+    border-top: none;
+}
+
+.--footer-meta a:link:not(.button){
+    position: relative;
+    opacity: 0.95;
+    margin-left: 20px;
+}
+
+.--footer-meta a {
+    font-weight: 400;
+    display: inline-block;
+    margin-left: 20px;
+    color: #3f3f3f;
+    margin: 2px 0;
+}
+
+.--footer-meta a::after {
+    display: none;
+}
+
+.--footer-meta .--wrap {
+    display: flex;
+    -webkit-box-pack: justify;
+    justify-content: space-between;
+    -webkit-box-align: center;
+    align-items: center;
+    opacity: 0.8;
+    width: 100%;
+    max-width: 100%;
+    margin: auto;
+}
+
+.--copyright {
+    color: #3f3f3f;
+}
+
+.--footer-meta .right {
+    display: flex;
+}
+
+article {
+    display: block;
 }

--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -1,33 +1,4 @@
-/* Plotly Custom Colors */
-
-/* Define the custom primary color scheme */
-[data-md-color-primary="custom"] {
-    --md-primary-fg-color: #6E56CF;
-    --md-primary-fg-color--light: #8B72D9;
-    --md-primary-fg-color--dark: #5A47B8;
-    --md-primary-bg-color: #FFFFFF;
-    --md-primary-bg-color--light: #F8F7FD;
-  }
-  
-  /* Define the custom accent color scheme */
-  [data-md-color-accent="custom"] {
-    --md-accent-fg-color: #6E56CF;
-    --md-accent-fg-color--transparent: rgba(110, 86, 207, 0.1);
-    --md-accent-bg-color: #FFFFFF;
-    --md-accent-bg-color--light: #F8F7FD;
-  }
-  
-  /* Additional custom properties for consistency */
-  :root {
-    --md-primary-fg-color: orange;
-    --plotly-primary: #6E56CF;
-    --plotly-primary-light: #8B72D9;
-    --plotly-primary-dark: #5A47B8;
-    --plotly-primary-alpha-10: rgba(110, 86, 207, 0.1);
-    --plotly-primary-alpha-20: rgba(110, 86, 207, 0.2);
-  }
-  
-  pre[hide_code="true"] {
+pre[hide_code="true"] {
     display: none;
 }
   
@@ -54,4 +25,8 @@
     height: auto !important;
     width: 100%;
     object-fit: contain;
+}
+
+.nav-bottom-image a::after {
+  content: none !important;
 }

--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -186,3 +186,79 @@ pre[hide_code="true"] {
 article {
     display: block;
 }
+
+.md-footer-meta__inner {
+    max-width: 100% !important;
+}
+
+.bottom-dash-img img {
+    margin-top: 20px;
+}
+
+.bottom-dash-img::after {
+    display: none;
+}
+
+/* Header Styling */
+
+.download-studio-btn {
+    display: inline-block;
+    font-weight: bold;
+    background: #7A76FF;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: background 0.3s ease;
+}
+
+.md-header__inner {
+    margin: 0;
+    max-width: 100% !important;
+}
+
+.md-header__title {
+    margin-left: 0 !important;
+}
+
+.md-header__inner a {
+    font-weight: 600;
+    font-size: 0.65rem;
+}
+
+.md-header__button.md-logo {
+    margin-left: 1.6rem;
+}
+
+.md-header__inner a::after {
+    display: none;
+}
+
+.md-header__inner ul{
+    list-style-type: none;
+    display: flex;
+    margin: 0;
+    padding: 0;
+}
+
+.md-header-ul li{
+    margin-right: 24px;
+}
+
+.md-header__inner ul li{
+    padding: 5px;
+    display: flex;
+    -webkit-box-pack: center;
+    justify-content: center;
+    -webkit-box-align: center;
+    align-items: center;
+    text-align: center;
+}
+
+@media screen and (max-width: 415px){
+    .md-header__inner ul{
+        display: none;
+    }
+
+}
+

--- a/pages/css/plotly-styles.css
+++ b/pages/css/plotly-styles.css
@@ -34,3 +34,24 @@
 .maplibregl-control-container {
   display: none;
 }
+
+.md-nav--primary {
+    position: relative; 
+    display: flex; 
+    flex-direction: column;
+}
+
+.nav-bottom-image{
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background: var(--md-default-bg-color);
+    padding: 30px 25px 0px 25px;
+    height: 12.1rem;
+}
+
+.nav-bottom-image img{
+    height: auto !important;
+    width: 100%;
+    object-fit: contain;
+}

--- a/pages/overrides/main.html
+++ b/pages/overrides/main.html
@@ -78,9 +78,9 @@ app.layout = html.Div([
 ])
 
 app.run(debug=True, use_reloader=False)  # Turn off reloader if inside Jupyter</code></pre>
-     <p><a
+     <p><a class="bottom-dash-img"
              href="https://dash.plotly.com/tutorial?utm_medium=graphing_libraries&utm_content=python_footer&_gl=1*3jyro3*_gcl_au*MTU5NjgzODk0NC4xNzU2OTk2NTI5*_ga*MTI3ODM0MzI1Mi4xNzQ3NzUxOTA5*_ga_6G7EE0JNSC*czE3NTg1NzAzMDgkbzI2JGcxJHQxNzU4NTcwOTg1JGo1MSRsMCRoMA.."><img
-                 src="{{ config.site_url }}assets/dash_2023.png" alt="Dash your way to interactive web apps"
+                 src="https://plotly.github.io/documentation/all_static/images/plotly-studio.png" alt="Dash your way to interactive web apps"
                  style="max-width: 100%; height: auto;"></a></p>
 {% endif %}
 

--- a/pages/overrides/main.html
+++ b/pages/overrides/main.html
@@ -1,5 +1,52 @@
 {% extends "base.html" %}
 
+{% block site_nav %}
+
+  <!-- Main navigation -->
+  {% if nav %}
+    {% if page and page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "navigation" in page.meta.hide %}
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--primary"
+      data-md-component="sidebar"
+      data-md-type="navigation"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/nav.html" %}
+        </div>
+
+        <div class="nav-bottom-image">
+            <a href="https://plotly.com/webinars/data-apps-publishing-playbook/?utm_medium=graphing_libraries&utm_campaign=plotly_publishing_playbook&utm_content=sidebar" target="_blank">
+                <img src="https://images.prismic.io/plotly-marketing-website-2/aNMW2J5xUNkB1CWg_PlotlyPublishingPlaybook.jpg?auto=format,compress" alt="plotly-studio-banner" type="image/avif">
+            </a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <!-- Table of contents -->
+  {% if not "toc.integrate" in features %}
+    {% if page and page.meta and page.meta.hide %}
+      {% set hidden = "hidden" if "toc" in page.meta.hide %}
+    {% endif %}
+    <div
+      class="md-sidebar md-sidebar--secondary"
+      data-md-component="sidebar"
+      data-md-type="toc"
+      {{ hidden }}
+    >
+      <div class="md-sidebar__scrollwrap">
+        <div class="md-sidebar__inner">
+          {% include "partials/toc.html" %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 <blockquote>
     <p><strong>Plotly Studio:</strong> Transform any dataset into an interactive data application in minutes with AI. <a

--- a/pages/overrides/partials/footer.html
+++ b/pages/overrides/partials/footer.html
@@ -63,7 +63,7 @@
                 </div>
                 <div class="right">
                     <article class="--tos">
-                        <a href="https://community.ploty.com/tos" target="_blank"> Terms of Service </a>
+                        <a href="https://community.plotly.com/tos" target="_blank"> Terms of Service </a>
                     </article>
                     <article class="--privacy">
                         <a href="https://plotly.com/privacy/" target="_blank"> Privacy Policy </a>

--- a/pages/overrides/partials/footer.html
+++ b/pages/overrides/partials/footer.html
@@ -1,0 +1,76 @@
+{% import "partials/language.html" as lang with context %}
+<footer class="md-footer">
+    <div class="md-footer-meta__inner md-grid">
+        <section class="--footer-top">
+            <div class="--wrap">
+                <ul class="--footer-body">
+                    <li class="--footer-column">
+                        <h6 class="--footer-heading">
+                            JOIN OUR MAILING LIST
+                        </h6>
+                        <ul>
+                            <li>
+                                <p class="subscribe-text">
+                                    Sign up to stay in the loop with all things Plotly — from Dash 
+                                    Club to product updates, webinars, and more!
+                                </p>
+                                <a href="https://go.plot.ly/subscription" class="subscribe-button" target="blank"> Subscribe </a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="--footer-column">
+                        <h6 class="--footer-heading"> Products </h6>
+                        <ul>
+                            <li><a href="https://plotly.com/studio" target="_self"> Plotly Studio </a></li>
+                            <li><a href="https://cloud.plotly.com" target="_self"> Plotly Cloud </a></li>
+                            <li><a href="https://plotly.com/dash/" target="_self"> Dash Enterprise </a></li>
+                            <li><a href="https://plotly.com/whats-new" target="_self"> New Releases → </a></li>
+                        </ul>
+                    </li>
+                    <li class="--footer-column">
+                        <h6 class="--footer-heading"> Pricing </h6>
+                        <ul>
+                            <li>
+                                <a href="https://plotly.com/pricing" target="_self"> Studio and Cloud Pricing</a>
+                            </li>
+                            <li>
+                                <a href="https://plotly.com/get-pricing" target="_self"> Dash Enterprise Pricing</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="--footer-column">
+                        <h6 class="--footer-heading"> About Us </h6>
+                        <ul>
+                            <li><a href="https://plotly.com/careers" target="_self"> Careers </a></li>
+                            <li><a href="https://plotly.com/resources/" target="_self"> Resources </a></li>
+                            <li><a href="https://plotly.com/blog/" target="_self"> Blog </a></li>
+                        </ul>
+                    </li>
+                    <li class="--footer-column">
+                        <h6 class="--footer-heading">Support </h6>
+                        <ul>
+                            <li><a href="https://community.plot.ly/" target="_self"> Community Support </a></li>
+                            <li><a href="https://plotly.com/graphing-libraries" target="_self"> Documentation </a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </section>
+        <section class="--footer-meta">
+            <div class="--wrap">
+                <div class="left">
+                    <article class="--copyright"> Copyright © 2025 Plotly. All rights reserved. </article>
+                </div>
+                <div class="right">
+                    <article class="--tos">
+                        <a href="https://community.ploty.com/tos" target="_blank"> Terms of Service </a>
+                    </article>
+                    <article class="--privacy">
+                        <a href="https://plotly.com/privacy/" target="_blank"> Privacy Policy </a>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </div>
+  </div>
+</footer>

--- a/pages/overrides/partials/header.html
+++ b/pages/overrides/partials/header.html
@@ -1,0 +1,80 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--shadow md-header--lifted" %}
+{% elif "navigation.tabs" not in features %}
+  {% set class = class ~ " md-header--shadow" %}
+{% endif %}
+<header class="{{ class }}" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header__button md-icon" for="__drawer">
+      {% set icon = config.theme.icon.menu or "material/menu" %}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+    </label>
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
+            {% endif %}
+          </span>
+        </div>
+      </div>
+    </div>
+    <ul class=".md-header-ul">
+        <li>
+            <a href="https://plotly.com/studio/?utm_medium=graphing_libraries" class="download-studio-btn"> Download Studio</a>
+        </li>
+        <li>
+            <a href="https://plotly.com/pricing"> Studio and Cloud Pricing </a>
+        </li>
+        <li>
+            <a href="https://plotly.com/get-pricing"> Dash Enterprise Pricing </a>
+        </li>
+    </ul>
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        {% include "partials/palette.html" %}
+      {% endif %}
+    {% endif %}
+    {% if not config.theme.palette is mapping %}
+      {% include "partials/javascripts/palette.html" %}
+    {% endif %}
+    {% if config.extra.alternate %}
+      {% include "partials/alternate.html" %}
+    {% endif %}
+    {% if "material/search" in config.plugins %}
+      {% set search = config.plugins["material/search"] | attr("config") %}
+      {% if search.enabled %}
+        <label class="md-header__button md-icon" for="__search">
+          {% set icon = config.theme.icon.search or "material/magnify" %}
+          {% include ".icons/" ~ icon ~ ".svg" %}
+        </label>
+        {% include "partials/search.html" %}
+      {% endif %}
+    {% endif %}
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
+</header>

--- a/pages/reference/graph_objects/index.md
+++ b/pages/reference/graph_objects/index.md
@@ -29,7 +29,7 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ### [Scatter](Scatter.md)
 
-### [Scattergl](Scattergl.md)
+### [Scatter GL](Scattergl.md)
 
 ### [Table](Table.md)
 
@@ -40,9 +40,9 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ### [Histogram](Histogram.md)
 
-### [Histogram2d](Histogram2d.md)
+### [Histogram 2D](Histogram2d.md)
 
-### [Histogram2dContour](Histogram2dContour.md)
+### [Histogram 2D Contour](Histogram2dContour.md)
 
 ### [Violin](Violin.md)
 
@@ -53,11 +53,11 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ### [Funnel](Funnel.md)
 
-### [Funnelarea](Funnelarea.md)
+### [Funnel Area](Funnelarea.md)
 
 ### [Indicator](Indicator.md)
 
-### [Ohlc](Ohlc.md)
+### [OHLC](Ohlc.md)
 
 ### [Waterfall](Waterfall.md)
 
@@ -68,9 +68,9 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ### [Isosurface](Isosurface.md)
 
-### [Mesh3d](Mesh3d.md)
+### [Mesh 3D](Mesh3d.md)
 
-### [Scatter3d](Scatter3d.md)
+### [Scatter 3D](Scatter3d.md)
 
 ### [Streamtube](Streamtube.md)
 
@@ -83,48 +83,48 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ### [Choropleth](Choropleth.md)
 
-### [Choroplethmap](Choroplethmap.md)
+### [Choropleth Map](Choroplethmap.md)
 
-### [Choroplethmapbox](Choroplethmapbox.md)
+### [Choropleth Mapbox](Choroplethmapbox.md)
 
-### [Densitymap](Densitymap.md)
+### [Density Map](Densitymap.md)
 
-### [Densitymapbox](Densitymapbox.md)
+### [Density Mapbox](Densitymapbox.md)
 
-### [Scattergeo](Scattergeo.md)
+### [Scatter Geo](Scattergeo.md)
 
-### [Scattermap](Scattermap.md)
+### [Scatter Map](Scattermap.md)
 
-### [Scattermapbox](Scattermapbox.md)
+### [Scatter Mapbox](Scattermapbox.md)
 
 
 ## Specialized Traces
 
-### [Barpolar](Barpolar.md)
+### [Bar Polar](Barpolar.md)
 
 ### [Carpet](Carpet.md)
 
-### [Contourcarpet](Contourcarpet.md)
+### [Contour Carpet](Contourcarpet.md)
 
 ### [Icicle](Icicle.md)
 
-### [Parcats](Parcats.md)
+### [Parallel Categories](Parcats.md)
 
-### [Parcoords](Parcoords.md)
+### [Parallel Coordinates](Parcoords.md)
 
 ### [Sankey](Sankey.md)
 
-### [Scattercarpet](Scattercarpet.md)
+### [Scatter Carpet](Scattercarpet.md)
 
-### [Scatterpolar](Scatterpolar.md)
+### [Scatter Polar](Scatterpolar.md)
 
-### [Scatterpolargl](Scatterpolargl.md)
+### [Scatter Polar GL](Scatterpolargl.md)
 
-### [Scattersmith](Scattersmith.md)
+### [Scatter Smith](Scattersmith.md)
 
-### [Scatterternary](Scatterternary.md)
+### [Scatter Ternary](Scatterternary.md)
 
-### [Splom](Splom.md)
+### [SPLOM](Splom.md)
 
 ### [Sunburst](Sunburst.md)
 
@@ -133,7 +133,7 @@ plotly.graph_objects contains the building blocks of plotly Figure: traces (Scat
 
 ## Other Classes
 
-### [FigureWidget](FigureWidget.md)
+### [Figure Widget](FigureWidget.md)
 
 ### [Frame](Frame.md)
 


### PR DESCRIPTION
- Adds plotly studio marketing image to the bottom of the navigation bar.
- Cleans up plotly-styles.css to remove unused styling
- Adds footer and header with links to other plotly projects and pricing like https://plotly.com/python/
- Fixes dash banner image broken link at the bottom of each page
- Adjusts titles of pages in navigation to keep it consistent with the plotly.js mkdocs build and https://plotly.com docs

Closes #95 and partially addresses #43